### PR TITLE
Make carousels actually use the full space taken up by an individual item to determine paging behavior accurately (keeping behavior as-is for instances where this isn't applicable)

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -1061,7 +1061,7 @@
                        (slider.maxW < slider.w) ? (slider.w - (slideMargin * (maxItems - 1)))/maxItems :
                        (slider.vars.itemWidth > slider.w) ? slider.w : slider.vars.itemWidth;
 
-        slider.visible = Math.floor(slider.w/(slider.itemW));
+        slider.visible = slider.itemW > 0 && slider.itemM > 0 ? Math.floor(slider.w / (slider.itemW + slider.itemM)) : Math.floor(slider.w / slider.itemW);
         slider.move = (slider.vars.move > 0 && slider.vars.move < slider.visible ) ? slider.vars.move : slider.visible;
         slider.pagingCount = Math.ceil(((slider.count - slider.visible)/slider.move) + 1);
         slider.last =  slider.pagingCount - 1;


### PR DESCRIPTION
Per previous discussion with @kevinbatdorf,

Regarding the bug, it is part of Flexslider & reported per https://github.com/woocommerce/FlexSlider/issues/1480, and it looks like it could be fixed in this fork of Flexslider as well.

You could/should replace
```
slider.visible = Math.floor(slider.w/(slider.itemW));
```
with
```
slider.visible = slider.itemW > 0 && slider.itemM > 0 ? Math.floor(slider.w / (slider.itemW + slider.itemM)) : Math.floor(slider.w / slider.itemW);
```
That way, sliders that are a carousel & have an item margin (which then have values that are available & can be used for calculation without issue) have their margin added to the item width so that the space used up by a slide is counted in total so pagination then behaves properly. Meanwhile, it then has the original value being used if/when that isn't the case for a given slider/carousel.

I'd appreciate seeing that implemented in the next version of MetaSlider since I've used this as a patch for now and I'd like to keep the site using the latest version of the plugin at all times. Let me know if you want me to provide or test anything at all.